### PR TITLE
Trying noarch buildg

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,9 +12,10 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record record.txt
-  skip: True  # [win]
+  #skip: True  # [win]
+  noarch: python
 
 requirements:
   build:


### PR DESCRIPTION
Testing out a noarch build. As pytmatrix exists in conda this should help to speed up builds. 